### PR TITLE
Readme를 보면서 설정하다가 추가로 검색하여 알게된 내용을 조금 추가했습니다

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ cd ios && pod install
 
 주의할 점은 다음과 같습니다.
 
-- 네이버 개발자 콘솔에 기입한 `URL Scheme`와 동일해야 합니다.
+- 네이버 개발자 콘솔에 기입한 `URL Scheme`와 동일해야 합니다. 앱스토어에 등록 된 다운로드URL이 없을 시 임의의 URL 등록 가능합니다 (예: 블로그 URL, 홈페이지 URL)
 - `login` 함수 호출시에 `serviceUrlScheme` 로 동일하게 전달해주어야 합니다.
 - TODO 설명 및 이미지 추가
 
@@ -98,9 +98,10 @@ cd ios && pod install
 </array>
 ```
 
+![스크린샷 2022-11-11 오후 3 00 57](https://user-images.githubusercontent.com/22087964/201274151-50e9d32c-8a94-4a8a-ace8-81f02a28e6ef.png)
 ![image](https://user-images.githubusercontent.com/33388801/196835050-3d887f3c-1d07-4be3-a2cf-27ed18a48691.png)
 
-#### 3. `AppDelegate`의 `application:openURL:options` 에서 URL 핸들링 로직 추가
+#### 3. `AppDelegate.m`의 `application:openURL:options` 에서 URL 핸들링 로직 추가
 
 네이버 로그인이 성공한 후 우리앱으로 다시 돌아와 URL을 처리하기 위해 필요한 과정입니다.
 


### PR DESCRIPTION
line.79 - URL Scheme 추가 설명란에 첨언 추가.
네이버 개발자 콘솔에서 URL Scheme을 기입하려면 반드시 다운로드URL이 필요한데, 어플 개발 테스트 중에는 다운로드URL이 없어서 방법을 찾던 중, 임의의 URL도 사용 가능하다는 것을 알게되어 첨언이 있으면 좋을거 같아서 추가합니다.

line.101 - Info.plist에 URL types를 추가 한 뒤 Xcode에서 나오는 화면 첨부합니다

line.104 - 'AppDelegate' 를 'AppDelegate.m'으로 변경해 보았습니다.